### PR TITLE
Add testnet entry for v8 BTC provider

### DIFF
--- a/lib/blockchainexplorer.js
+++ b/lib/blockchainexplorer.js
@@ -26,7 +26,8 @@ var PROVIDERS = {
 
   'v8': {
     'btc': {
-      'livenet': 'https://api.bitpay.com:',
+      'livenet': 'https://api.bitpay.com',
+      'testnet': 'http://localhost:3001'
     },
     'bch': {
       'testnet': 'http://localhost:3001',


### PR DESCRIPTION
The missing entry prevents configuring your own endpoint in config.js.